### PR TITLE
fix(s3): better prefix handling

### DIFF
--- a/apps/examples/aws-example/setup.py
+++ b/apps/examples/aws-example/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "0.1.1"
+version = "0.1.2"
 
 setuptools.setup(
     name="aws_example",

--- a/plugins/aws/s3/setup.py
+++ b/plugins/aws/s3/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "0.1.1"
+version = "0.1.2"
 
 setuptools.setup(
     name="hopeit.aws.s3",

--- a/plugins/aws/s3/src/hopeit/aws/s3/object_storage.py
+++ b/plugins/aws/s3/src/hopeit/aws/s3/object_storage.py
@@ -200,7 +200,10 @@ class ObjectStorage(Generic[DataObject]):
                 try:
                     await object_storage.create_bucket(Bucket=self.bucket, **kwargs)
                 except ClientError as e:
-                    if e.response["Error"]["Code"] in ["BucketAlreadyOwnedByYou", "BucketAlreadyExists"]:                        
+                    if e.response["Error"]["Code"] in [
+                        "BucketAlreadyOwnedByYou",
+                        "BucketAlreadyExists",
+                    ]:
                         pass
                     else:
                         raise e
@@ -223,9 +226,9 @@ class ObjectStorage(Generic[DataObject]):
         """
 
         async with self._session.client(S3, **self._conn_config) as object_storage:
+            key = f"{partition_key}/{key}" if partition_key else key
+            key = f"{self.prefix or ''}{key}"
             try:
-                key = f"{partition_key}/{key}" if partition_key else key
-                key = f"{self.prefix or ''}{key}"
                 file_obj = BytesIO()
                 await object_storage.download_fileobj(
                     self.bucket, key + SUFFIX, file_obj
@@ -254,7 +257,6 @@ class ObjectStorage(Generic[DataObject]):
         """
 
         async with self._session.client(S3, **self._conn_config) as object_storage:
-
             file_name = f"{partition_key}/{file_name}" if partition_key else file_name
             file_name = f"{self.prefix or ''}{file_name}"
             try:

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,12 @@
 Release Notes
 =============
 
+Version 0.1.2
+_____________
+- hopeit.aws.s3 
+
+   - Fix: Better `prefix` handling in `get_files`, `list_files`, and `list_objects`. Consistent location return on `store` and `store_file`.
+
 Version 0.1.1
 _____________
 - hopeit.aws.s3 


### PR DESCRIPTION
Better `prefix` handling in `get_files`, `list_files`, and `list_objects`. 
Consistent location return on `store` and `store_file`.