### PR TITLE
update(engine) : Update Compatibility with hopeit.engine 0.25.0

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
                 "OBJECT_STORAGE_SECRET_ACCESS_KEY": "Hopei#Engine#2020",
                 "OBJECT_STORAGE_ENDPOINT_URL": "http://localhost:9000",
                 "OBJECT_STORAGE_SSL": "false",
-                "HOPEIT_AWS_API_VERSION": "0.1"
+                "HOPEIT_AWS_API_VERSION": "0.2"
             },
             "justMyCode": true,
             "serverReadyAction": {

--- a/apps/examples/aws-example/api/openapi.json
+++ b/apps/examples/aws-example/api/openapi.json
@@ -1,12 +1,12 @@
 {
   "openapi": "3.0.3",
   "info": {
-    "version": "0.1",
+    "version": "0.2",
     "title": "AWS Example",
     "description": "AWS Example"
   },
   "paths": {
-    "/api/aws-example/0x1/s3/save-something": {
+    "/api/aws-example/0x2/s3/save-something": {
       "post": {
         "summary": "AWS Example: Save Something",
         "description": "Creates and saves Something",
@@ -83,11 +83,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/query-something": {
+    "/api/aws-example/0x2/s3/query-something": {
       "post": {
         "summary": "AWS Example: Query Something",
         "description": "Loads Something from s3",
@@ -153,11 +153,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/list-objects": {
+    "/api/aws-example/0x2/s3/list-objects": {
       "get": {
         "summary": "AWS Example: List Objects",
         "description": "Lists all available Something objects",
@@ -207,11 +207,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/list-files": {
+    "/api/aws-example/0x2/s3/list-files": {
       "get": {
         "summary": "AWS Example: List Files",
         "description": "Lists all available Something objects",
@@ -261,11 +261,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/upload-download-file": {
+    "/api/aws-example/0x2/s3/upload-download-file": {
       "get": {
         "summary": "AWS Example: Upload Download File",
         "description": "This example just upload and download files to s2 storage as example of usage",
@@ -325,11 +325,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/streamed-upload-file": {
+    "/api/aws-example/0x2/s3/streamed-upload-file": {
       "post": {
         "summary": "AWS Example: Streamed Upload File",
         "description": "Upload files using Multipart form request",
@@ -414,11 +414,11 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     },
-    "/api/aws-example/0x1/s3/streamed-download-file": {
+    "/api/aws-example/0x2/s3/streamed-download-file": {
       "get": {
         "summary": "AWS Example: Streamed Download File",
         "description": "Download streamed S3 content as file.\nThe PostprocessHook return the requested resource as stream using `prepare_stream_response`.",
@@ -494,7 +494,7 @@
           }
         },
         "tags": [
-          "aws_example.0x1"
+          "aws_example.0x2"
         ]
       }
     }
@@ -502,149 +502,171 @@
   "components": {
     "schemas": {
       "SomethingParams": {
-        "type": "object",
+        "description": "Params to create and save Something",
+        "properties": {
+          "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "user": {
+            "title": "User",
+            "type": "string"
+          }
+        },
         "required": [
           "id",
           "user"
         ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "user": {
-            "type": "string"
-          }
-        },
-        "x-module-name": "aws_example.model",
-        "description": "Params to create and save Something"
-      },
-      "User": {
-        "type": "object",
-        "required": [
-          "id",
-          "name"
-        ],
-        "properties": {
-          "id": {
-            "type": "string"
-          },
-          "name": {
-            "type": "string"
-          }
-        },
-        "x-module-name": "aws_example.model",
-        "description": "User information"
+        "title": "SomethingParams",
+        "type": "object"
       },
       "Status": {
-        "type": "object",
+        "description": "Status change",
+        "properties": {
+          "ts": {
+            "format": "date-time",
+            "title": "Ts",
+            "type": "string"
+          },
+          "type": {
+            "$ref": "#/components/schemas/StatusType"
+          }
+        },
         "required": [
           "ts",
           "type"
         ],
-        "properties": {
-          "ts": {
-            "type": "string",
-            "format": "date-time"
-          },
-          "type": {
-            "type": "string",
-            "enum": [
-              "NEW",
-              "LOADED",
-              "SUBMITTED",
-              "PROCESSED"
-            ],
-            "x-enum-name": "StatusType",
-            "x-module-name": "aws_example.model"
-          }
-        },
-        "x-module-name": "aws_example.model",
-        "description": "Status change"
+        "title": "Status",
+        "type": "object"
       },
-      "Something": {
-        "type": "object",
-        "required": [
-          "id",
-          "user"
+      "StatusType": {
+        "enum": [
+          "NEW",
+          "LOADED",
+          "SUBMITTED",
+          "PROCESSED"
         ],
+        "title": "StatusType",
+        "type": "string"
+      },
+      "User": {
+        "description": "User information",
         "properties": {
           "id": {
+            "title": "Id",
+            "type": "string"
+          },
+          "name": {
+            "title": "Name",
+            "type": "string"
+          }
+        },
+        "required": [
+          "id",
+          "name"
+        ],
+        "title": "User",
+        "type": "object"
+      },
+      "Something": {
+        "description": "Example Something event",
+        "properties": {
+          "id": {
+            "title": "Id",
             "type": "string"
           },
           "user": {
             "$ref": "#/components/schemas/User"
           },
           "status": {
-            "$ref": "#/components/schemas/Status"
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/Status"
+              }
+            ],
+            "default": null,
+            "nullable": true
           },
           "history": {
-            "type": "array",
             "items": {
               "$ref": "#/components/schemas/Status"
             },
-            "default": []
+            "title": "History",
+            "type": "array"
           }
         },
-        "x-module-name": "aws_example.model",
-        "description": "Example Something event"
+        "required": [
+          "id",
+          "user"
+        ],
+        "title": "Something",
+        "type": "object"
       },
       "SomethingNotFound": {
-        "type": "object",
+        "description": "Item not found in datastore",
+        "properties": {
+          "path": {
+            "title": "Path",
+            "type": "string"
+          },
+          "id": {
+            "title": "Id",
+            "type": "string"
+          }
+        },
         "required": [
           "path",
           "id"
         ],
-        "properties": {
-          "path": {
-            "type": "string"
-          },
-          "id": {
-            "type": "string"
-          }
-        },
-        "x-module-name": "aws_example.model",
-        "description": "Item not found in datastore"
+        "title": "SomethingNotFound",
+        "type": "object"
       },
       "ItemLocator": {
-        "type": "object",
-        "required": [
-          "item_id"
-        ],
         "properties": {
           "item_id": {
+            "title": "Item Id",
             "type": "string"
           },
           "partition_key": {
+            "default": null,
+            "nullable": true,
+            "title": "Partition Key",
             "type": "string"
           }
         },
-        "x-module-name": "hopeit.aws.s3.object_storage",
-        "description": "ItemLocator(item_id: str, partition_key: Union[str, NoneType] = None)"
+        "required": [
+          "item_id"
+        ],
+        "title": "ItemLocator",
+        "type": "object"
       },
       "UploadedFile": {
-        "type": "object",
+        "properties": {
+          "file_id": {
+            "title": "File Id",
+            "type": "string"
+          },
+          "file_name": {
+            "title": "File Name",
+            "type": "string"
+          },
+          "saved_path": {
+            "title": "Saved Path",
+            "type": "string"
+          },
+          "size": {
+            "title": "Size",
+            "type": "integer"
+          }
+        },
         "required": [
           "file_id",
           "file_name",
           "saved_path",
           "size"
         ],
-        "properties": {
-          "file_id": {
-            "type": "string"
-          },
-          "file_name": {
-            "type": "string"
-          },
-          "saved_path": {
-            "type": "string"
-          },
-          "size": {
-            "type": "integer"
-          }
-        },
-        "x-module-name": "aws_example.s3.streamed_upload_file",
-        "description": "UploadedFile(file_id: str, file_name: str, saved_path: str, size: int)"
+        "title": "UploadedFile",
+        "type": "object"
       }
     },
     "securitySchemes": {

--- a/apps/examples/aws-example/setup.py
+++ b/apps/examples/aws-example/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "0.1.3"
+version = "0.2.0b1"
 
 setuptools.setup(
     name="aws_example",

--- a/apps/examples/aws-example/src/aws_example/model/__init__.py
+++ b/apps/examples/aws-example/src/aws_example/model/__init__.py
@@ -2,12 +2,11 @@
 Data model for aws-example test application
 """
 
-from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum
 from typing import List, Optional
 
-from hopeit.dataobjects import dataobject
+from hopeit.dataobjects import dataclass, dataobject, field
 
 
 class StatusType(str, Enum):

--- a/apps/examples/aws-example/src/aws_example/s3/streamed_download_file.py
+++ b/apps/examples/aws-example/src/aws_example/s3/streamed_download_file.py
@@ -5,14 +5,13 @@ Download streamed S3 content as file.
 The PostprocessHook return the requested resource as stream using `prepare_stream_response`.
 """
 
-from dataclasses import dataclass
 from typing import Optional
 
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext, PostprocessHook
 from hopeit.app.logger import app_extra_logger
 from hopeit.aws.s3 import ObjectStorage, ObjectStorageSettings
-from hopeit.dataobjects import BinaryDownload
+from hopeit.dataobjects import BinaryDownload, dataclass
 
 object_storage: Optional[ObjectStorage] = None
 logger, extra = app_extra_logger()

--- a/apps/examples/aws-example/src/aws_example/s3/streamed_upload_file.py
+++ b/apps/examples/aws-example/src/aws_example/s3/streamed_upload_file.py
@@ -5,14 +5,13 @@ Uploads file using multipart upload support. Returns metadata Something object.
 ```
 """
 
-from dataclasses import dataclass, field
 from typing import List, Optional, Union
 
 from hopeit.app.api import event_api
 from hopeit.app.context import EventContext, PreprocessHook
 from hopeit.app.logger import app_extra_logger
 from hopeit.aws.s3 import ObjectStorage, ObjectStorageSettings
-from hopeit.dataobjects import BinaryAttachment, dataobject
+from hopeit.dataobjects import BinaryAttachment, dataclass, dataobject, field
 
 object_storage: Optional[ObjectStorage] = None
 logger, extra = app_extra_logger()

--- a/apps/examples/aws-example/src/aws_example/s3/upload_download_file.py
+++ b/apps/examples/aws-example/src/aws_example/s3/upload_download_file.py
@@ -5,7 +5,6 @@ Uploads file using multipart upload support. Returns metadata Something object.
 ```
 """
 
-from dataclasses import dataclass, field
 from typing import List, Optional
 
 import aiofiles
@@ -13,7 +12,7 @@ from hopeit.app.api import event_api
 from hopeit.app.context import EventContext
 from hopeit.app.logger import app_extra_logger
 from hopeit.aws.s3 import ObjectStorage, ObjectStorageSettings
-from hopeit.dataobjects import dataobject
+from hopeit.dataobjects import dataclass, dataobject, field
 
 object_storage: Optional[ObjectStorage] = None
 logger, extra = app_extra_logger()

--- a/plugins/aws/s3/README.md
+++ b/plugins/aws/s3/README.md
@@ -19,8 +19,7 @@ pip install hopeit.aws.s3
 ### Usage
 
 ```python
-from dataclasses import dataclass
-from hopeit.dataobjects import dataobject
+from hopeit.dataobjects import dataobject, dataclass
 from hopeit.aws.s3 import ObjectStorage, ObjectStorageSettings, ConnectionConfig
 
 # Create a connection configuration

--- a/plugins/aws/s3/requirements.txt
+++ b/plugins/aws/s3/requirements.txt
@@ -1,2 +1,2 @@
-hopeit.engine==0.25.0b1
+hopeit.engine>=0.25.0b1
 aioboto3>=13.0.1

--- a/plugins/aws/s3/requirements.txt
+++ b/plugins/aws/s3/requirements.txt
@@ -1,2 +1,2 @@
-hopeit.engine>=0.24.2,<1
-aioboto3>=13.0.0
+hopeit.engine==0.25.0b1
+aioboto3>=13.0.1

--- a/plugins/aws/s3/setup.py
+++ b/plugins/aws/s3/setup.py
@@ -1,6 +1,6 @@
 import setuptools
 
-version = "0.1.3"
+version = "0.2.0b1"
 
 setuptools.setup(
     name="hopeit.aws.s3",

--- a/plugins/aws/s3/src/hopeit/aws/s3/object_storage.py
+++ b/plugins/aws/s3/src/hopeit/aws/s3/object_storage.py
@@ -5,7 +5,6 @@ Storage/persistence asynchronous stores and gets files from object storage.
 
 import fnmatch
 import os
-from dataclasses import dataclass
 from io import BytesIO
 from pathlib import Path
 from typing import (
@@ -24,7 +23,7 @@ from typing import (
 
 from aioboto3 import Session  # type: ignore
 from botocore.exceptions import ClientError
-from hopeit.dataobjects import DataObject, dataobject
+from hopeit.dataobjects import DataObject, dataclass, dataobject
 from hopeit.dataobjects.payload import Payload
 
 from .partition import get_file_partition_key, get_partition_key
@@ -400,7 +399,7 @@ class ObjectStorage(Generic[DataObject]):
         """
 
         region_name = os.getenv("AWS_DEFAULT_REGION")
-        if region_name and "region_name" not in self._conn_config:
+        if region_name and self._conn_config.get("region_name") is None:
             self._conn_config["region_name"] = region_name
 
         kwargs = (
@@ -409,7 +408,7 @@ class ObjectStorage(Generic[DataObject]):
                     "LocationConstraint": self._conn_config["region_name"]
                 }
             }
-            if self._conn_config.get("region_name", None) is not None
+            if self._conn_config.get("region_name") is not None
             else {}
         )
 

--- a/plugins/aws/s3/test/unit/test_s3.py
+++ b/plugins/aws/s3/test/unit/test_s3.py
@@ -3,7 +3,6 @@ hopeit.aws.s3 tests
 """
 
 import io
-from dataclasses import dataclass
 from time import sleep
 from typing import Optional
 
@@ -15,7 +14,7 @@ from hopeit.aws.s3 import (
     ObjectStorage,
     ObjectStorageSettings,
 )
-from hopeit.dataobjects import dataobject
+from hopeit.dataobjects import dataclass, dataobject
 from moto.server import ThreadedMotoServer
 
 

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,6 +1,17 @@
 Release Notes
 =============
 
+Version 0.2.0b1
+_____________
+- hopeit.aws.s3 
+
+   - Updated to be compatible with `hopeit.engine` version 0.25.0.
+   
+   BREAKING CHANGES
+   ================
+
+   - This version is not backward compatible with previous version of the `hopeit.engine`.
+
 Version 0.1.3
 _____________
 - hopeit.aws.s3 
@@ -8,7 +19,7 @@ _____________
    - Extracted bucket creation logic from settings into a separate method `bucket_creation`.
    - Set default listing behavior to non-recursive, treating subdirectories as part of the key; partitions only show the partition part of the key.
    - Use `_build_key` method internally to handle prefix and partitioning part of the key.
-   - In the `aws_example`` app, moved `create_bucket` from endpoint initialization to an initialization SETUP event.
+   - In the `aws_example` app, moved `create_bucket` from endpoint initialization to an initialization SETUP event.
 
 Version 0.1.2
 _____________

--- a/release-notes.rst
+++ b/release-notes.rst
@@ -1,7 +1,7 @@
 Release Notes
 =============
 
-Version 0.2.0b1
+Version 0.2.0
 _____________
 - hopeit.aws.s3 
 
@@ -10,7 +10,7 @@ _____________
    BREAKING CHANGES
    ================
 
-   - This version is not backward compatible with previous version of the `hopeit.engine`.
+   - This version is not backward compatible with previous version of `hopeit.engine`.
 
 Version 0.1.3
 _____________


### PR DESCRIPTION
This pull request updates the hopeit.aws.s3 plugin to be compatible with hopeit.engine version 0.25.0. It includes changes to ensure that the plugin works seamlessly with the latest version of the engine.

Changes:

    Updated compatibility with hopeit.engine version 0.25.0.

Breaking Changes:

    This update is not backward compatible with previous versions of hopeit.engine.